### PR TITLE
(QA-2101) Add Path Helper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+#this will probably not be available on rubygems, at least initially
+#will probably be only available at https://rubygems.delivery.puppetlabs.net
+#TODO: Change this line when it is actually available internally
+
+# Specify your gem's dependencies in beaker_windows.gemspec
+gemspec

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Beaker Windows
+
+Beaker helper library for testing on Windows.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+    gem 'beaker_windows'
+
+And then execute:
+
+    $ bundle install
+
+Or install it yourself as:
+
+    $ gem install beaker_windows
+
+## Methods
+
+### join_path
+
+Join paths together with a "\" Windows style path separator. This method will
+accept path segments with mixed separators as well as leading and trailing
+separators. Optionally you can specify to use an alternate path separator or
+strip the drive letter off the combined path.
+
+#### Example 1
+
+    join_path('c:\dog', 'bark')
+
+#### Example 2
+
+    join_path('c:\dog', 'bark', :path_sep => '/')
+
+#### Example 3
+
+    join_path('c:\dog', 'bark', :path_sep => '/', :strip_drive => true)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,11 @@
+require "bundler/gem_tasks"
+
+require 'rspec/core/rake_task'
+
+task :default => :test
+
+desc "Run spec tests"
+RSpec::Core::RakeTask.new(:test) do |t|
+  t.rspec_opts = ['--color']
+  t.pattern = 'spec/'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,9 @@ require "bundler/gem_tasks"
 
 require 'rspec/core/rake_task'
 
-task :default => :test
+task :default do
+  system 'rake --tasks'
+end
 
 desc "Run spec tests"
 RSpec::Core::RakeTask.new(:test) do |t|

--- a/beaker_windows.gemspec
+++ b/beaker_windows.gemspec
@@ -1,0 +1,28 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'beaker_windows/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'beaker_windows'
+  spec.version       = BeakerWindows::Version::STRING
+  spec.authors       = ['Puppet Labs']
+  spec.email         = ['qa@puppetlabs.com']
+  spec.summary       = 'Puppet Labs testing library for testing on Windows.'
+  spec.description   = 'This Gem extends the Beaker DSL for the verify state on Windows nodes.'
+  spec.homepage      = 'https://github.com/puppetlabs/beaker_windows'
+  spec.license       = 'Apache-2.0'
+  spec.files         = Dir['[A-Z]*[^~]'] + Dir['lib/**/*.rb'] + Dir['spec/*']
+  spec.test_files    = Dir['spec/*']
+
+  # Development dependencies
+  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'pry-byebug', '~> 3.3'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec', '>= 3.0.0'
+  spec.add_development_dependency 'simplecov'
+
+  # Documentation dependencies
+  spec.add_development_dependency 'yard', '~> 0'
+  spec.add_development_dependency 'markdown', '~> 0'
+end

--- a/lib/beaker_windows.rb
+++ b/lib/beaker_windows.rb
@@ -1,0 +1,8 @@
+module Beaker
+  class TestCase
+    %w( path ).each do |lib|
+      require "beaker_windows/#{lib}"
+    end
+    include BeakerWindows::Path
+  end
+end

--- a/lib/beaker_windows/path.rb
+++ b/lib/beaker_windows/path.rb
@@ -1,0 +1,55 @@
+module BeakerWindows
+  module Path
+
+    # Combine string containing paths with mixed separators. Coerce the path
+    # to Windows style automatically. (Configurable)
+    #
+    # ==== Attributes
+    #
+    # * +*paths+ - Two or more strings containing paths to be joined.
+    # * +opts+ - An options hash - not required
+    #   * +:path_sep+ - The desired path separator to use. (Default: "\")
+    #   * +:strip_drive+ - A boolean flag indicating of the drive letter should be stripped.
+    #
+    # ==== Returns
+    #
+    # +string+ - An absolute path to the manifests for an environment on the master host.
+    #
+    # ==== Raises
+    #
+    # +ArgumentError+ - Too few arguments.
+    #
+    # ==== Example
+    # join_path('c:\meow', 'cats/', 'bats\')
+    # join_path('c:\dog', 'bark', :strip_drive => true)
+    def join_path(*args)
+      # Init
+      opts = args.last.is_a?(Hash) ? args.pop : {}
+      opts[:path_sep] ||= "\\"
+      opts[:strip_drive] ||= false
+
+      combined_path = ''
+
+      # Verify that the user provided at least to paths to combine
+      raise(ArgumentError, "Too few arguments") if args.length < 2
+
+      # Combine the paths
+      args.each do |path|
+        # Verify that the provided args are strings
+        raise(ArgumentError, "Non-string provided as path") unless path.is_a?(String)
+
+        combined_path << opts[:path_sep].to_s unless combined_path.empty?
+        combined_path << path.gsub(/(\\|\/)/, opts[:path_sep].to_s)
+      end
+
+      # Remove duplicate path separators
+      combined_path.gsub!(/(\\|\/){2,}/, opts[:path_sep].to_s)
+
+      # Strip the drive letter if needed
+      combined_path.sub!(/^\w:/, '') if opts[:strip_drive]
+
+      return combined_path
+    end
+
+  end
+end

--- a/lib/beaker_windows/path.rb
+++ b/lib/beaker_windows/path.rb
@@ -30,7 +30,7 @@ module BeakerWindows
 
       combined_path = ''
 
-      # Verify that the user provided at least to paths to combine
+      # Verify that the user provided at least two paths to combine
       raise(ArgumentError, "Too few arguments") if args.length < 2
 
       # Combine the paths

--- a/lib/beaker_windows/version.rb
+++ b/lib/beaker_windows/version.rb
@@ -1,0 +1,5 @@
+module BeakerWindows
+  module Version
+    STRING = '0.1.0'
+  end
+end

--- a/spec/beaker_windows/path_spec.rb
+++ b/spec/beaker_windows/path_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+describe BeakerWindows::Path do
+  let(:dummy_class) { Class.new { extend BeakerWindows::Path } }
+  let(:path_1)                 { 'c:\cats' }
+  let(:path_2)                 { 'go\meow' }
+  let(:path_3)                 { 'and\dogs\go\bark' }
+
+  describe '#join_path' do
+
+    it 'should combine simple paths' do
+      exp = 'c:\cats\go\meow\and\dogs\go\bark'
+
+      expect(dummy_class.join_path(path_1, path_2, path_3)).to eq(exp)
+    end
+
+    it 'should combine paths using alternate separator' do
+      exp = 'c:/cats/go/meow/and/dogs/go/bark'
+
+      expect(dummy_class.join_path(path_1, path_2, path_3, :path_sep => '/')).to eq(exp)
+    end
+
+    it 'should combine paths and strip drive letter' do
+      exp = '\cats\go\meow\and\dogs\go\bark'
+
+      expect(dummy_class.join_path(path_1, path_2, path_3, :strip_drive => true)).to eq(exp)
+    end
+
+    it 'should combine paths using alternate separator and strip drive letter' do
+      exp = '/cats/go/meow/and/dogs/go/bark'
+
+      expect(dummy_class.join_path(path_1, path_2, path_3, :path_sep => '/', :strip_drive => true)).to eq(exp)
+    end
+
+    it 'should combine paths with mixed separators' do
+      path_1 = 'c:\cats\go\meow'
+      path_2 = 'and/dogs/go/bark'
+      exp = 'c:\cats\go\meow\and\dogs\go\bark'
+
+      expect(dummy_class.join_path(path_1, path_2)).to eq(exp)
+    end
+
+    it 'should combine paths with leading and trailing separators' do
+      path_1 = "c:\\cats\\go\\meow\\"
+      path_2 = '/and/dogs/go/bark'
+      exp = 'c:\cats\go\meow\and\dogs\go\bark'
+
+      expect(dummy_class.join_path(path_1, path_2)).to eq(exp)
+    end
+
+    it 'should combine paths with leading and trailing separators using alternate separator' do
+      path_1 = "c:\\cats\\go\\meow\\"
+      path_2 = '/and/dogs/go/bark'
+      exp = 'c:/cats/go/meow/and/dogs/go/bark'
+
+      expect(dummy_class.join_path(path_1, path_2, :path_sep => '/')).to eq(exp)
+    end
+
+    it 'should combine heinous paths' do
+      path_1 = "c:\\//cats\\go\\\\\\meow\\\\"
+      path_2 = '/////////and\\dogs/\go\\bark'
+      exp = 'c:\cats\go\meow\and\dogs\go\bark'
+
+      expect(dummy_class.join_path(path_1, path_2)).to eq(exp)
+    end
+
+    it 'should combine heinous paths using alternate separator' do
+      path_1 = "c:\\//cats\\go\\\\\\meow\\\\"
+      path_2 = '/////////and\\dogs/\go\\bark'
+      exp = 'c:/cats/go/meow/and/dogs/go/bark'
+
+      expect(dummy_class.join_path(path_1, path_2, :path_sep => '/')).to eq(exp)
+    end
+
+    context 'negative' do
+
+      it 'should fail with only one path' do
+        expect{ dummy_class.join_path(path_1) }.to raise_error(ArgumentError)
+      end
+
+      it 'should fail with invalid data type' do
+        expect{ dummy_class.join_path(path_1, 3) }.to raise_error(ArgumentError)
+      end
+
+    end
+
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,10 @@
+require 'simplecov'
+require 'rspec'
+
+SimpleCov.start
+
+require 'beaker_windows'
+
+RSpec.configure do |c|
+
+end


### PR DESCRIPTION
Originally planned for three different path helpers, but instead decided to
get fancy! The new "join_path" method will allow for flexibility in path
joining, but default to assuming to join paths as if on Windows.
