### PR TITLE
(QA-2402) Rename Repository

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 #will probably be only available at https://rubygems.delivery.puppetlabs.net
 #TODO: Change this line when it is actually available internally
 
-# Specify your gem's dependencies in beaker_windows.gemspec
+# Specify your gem's dependencies in beaker-windows.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Beaker helper library for testing on Windows.
 
 Add this line to your application's Gemfile:
 
-    gem 'beaker_windows'
+    gem 'beaker-windows'
 
 And then execute:
 
@@ -14,7 +14,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install beaker_windows
+    $ gem install beaker-windows
 
 ## Methods
 

--- a/beaker_windows.gemspec
+++ b/beaker_windows.gemspec
@@ -1,16 +1,16 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'beaker_windows/version'
+require 'beaker-windows/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'beaker_windows'
+  spec.name          = 'beaker-windows'
   spec.version       = BeakerWindows::Version::STRING
   spec.authors       = ['Puppet Labs']
   spec.email         = ['qa@puppetlabs.com']
   spec.summary       = 'Puppet Labs testing library for testing on Windows.'
   spec.description   = 'This Gem extends the Beaker DSL for the verify state on Windows nodes.'
-  spec.homepage      = 'https://github.com/puppetlabs/beaker_windows'
+  spec.homepage      = 'https://github.com/puppetlabs/beaker-windows'
   spec.license       = 'Apache-2.0'
   spec.files         = Dir['[A-Z]*[^~]'] + Dir['lib/**/*.rb'] + Dir['spec/*']
   spec.test_files    = Dir['spec/*']

--- a/lib/beaker_windows.rb
+++ b/lib/beaker_windows.rb
@@ -1,7 +1,7 @@
 module Beaker
   class TestCase
     %w( path powershell ).each do |lib|
-      require "beaker_windows/#{lib}"
+      require "beaker-windows/#{lib}"
     end
     include BeakerWindows::Path
     include BeakerWindows::Powershell

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require 'rspec'
 
 SimpleCov.start
 
-require 'beaker_windows'
+require 'beaker-windows'
 
 RSpec.configure do |c|
 


### PR DESCRIPTION
The underscore was causing problems for the QE team so the repo and corresponding
references in files have been renamed to "beaker-windows".
