### PR TITLE
(QA-2403) Update Gemfile with Groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,24 @@ source 'https://rubygems.org'
 #will probably be only available at https://rubygems.delivery.puppetlabs.net
 #TODO: Change this line when it is actually available internally
 
-# Specify your gem's dependencies in beaker-windows.gemspec
+# Shared
+gem 'bundler', '~> 1.6'
+gem 'rake', '~> 10.0'
+gem 'beaker', '~> 2.32'
+
+group :build do
+  gem 'yard', '~> 0'
+  gem 'markdown', '~> 0'
+end
+
+group :development do
+  gem 'pry-byebug', '~> 3.3'
+end
+
+group :test do
+  gem 'rspec', '~> 3.0',      :require => false
+  gem 'simplecov', '~> 0.11', :require => false
+end
+
+# Load the beaker-windows.gemspec
 gemspec

--- a/beaker-windows.gemspec
+++ b/beaker-windows.gemspec
@@ -14,16 +14,4 @@ Gem::Specification.new do |spec|
   spec.license       = 'Apache-2.0'
   spec.files         = Dir['[A-Z]*[^~]'] + Dir['lib/**/*.rb'] + Dir['spec/*']
   spec.test_files    = Dir['spec/*']
-
-  # Development dependencies
-  spec.add_development_dependency 'bundler', '~> 1.6'
-  spec.add_development_dependency 'pry-byebug', '~> 1.2'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'simplecov', '~> 0.11'
-  spec.add_development_dependency 'beaker', '~> 2.32'
-
-  # Documentation dependencies
-  spec.add_development_dependency 'yard', '~> 0'
-  spec.add_development_dependency 'markdown', '~> 0'
 end


### PR DESCRIPTION
The "pry-byebug" gem is causing issues for 1.9.3 so the Gemfile has
been updated to use groups to guard against installing the gem when
running spec tests.
