### PR TITLE
(QA-2403) Remove "pry-byebug"

### DIFF
--- a/beaker-windows.gemspec
+++ b/beaker-windows.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
 
   # Development dependencies
   spec.add_development_dependency 'bundler', '~> 1.6'
-  spec.add_development_dependency 'pry-byebug', '~> 1.2'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov', '~> 0.11'


### PR DESCRIPTION
The gem dependency isn't strcitly necessary and is causing headaches for the
CI pipeline.
